### PR TITLE
Separate suggestions from bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,22 +1,22 @@
 ---
-name: Bug report
-about: Create a report to help us improve
+name: Bug Report
+about: Create a bug report to help us fix issues
 title: ''
-labels: ''
+labels: 'bug'
 assignees: ''
 
 ---
 
-# When giving your report a title, please append a [LABEL], example [LABEL]s include:
-# [PSP], [NX] (Nintendo Switch), [VITA], [SERVER] (for game code), [CSQC] (for PC hud or viewmodel stuff), [MENU] (for PC menu)
-# If related to CO-OP,  append "CO-OP/" to the label, (e.g. [CO-OP/SERVER].
-# If this is a Suggestion please append the label [SUGGESTION].
+# When giving your report a title, please prepend a [LABEL], example [LABEL]s include:
+# [SERVER] (for game code), [CLIENT] (for HUD elements or other client side stuff),
+# [PSP/3DS/NX/VITA/FTE] (for engine based code specific to the platform).
+# If related to CO-OP, prepend "CO-OP/" to the label, (e.g. [CO-OP/SERVER].
 **Describe the bug**
 A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
-1. Go to '...'
+1. Go to '....'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
@@ -25,16 +25,18 @@ Steps to reproduce the behavior:
 A clear and concise description of what you expected to happen.
 
 **Screenshots/Footage**
-If applicable, add screenshots or video to help explain your problem.
+If applicable, add screenshots or a video to help explain your problem.
 
-**Affected Platforms:**
+**Affected Platforms**
 
-# Please make note of any platforms you DID NOT test on.
+# State which platform(s) you've seen the bug occur.
+# Please also make note of any platforms you DID NOT test on.
 
-- PSP
-- PS VITA
+- PSP (1k, 2k, 3k, Go, Street)
+- PS Vita (1k, 2k)
 - Nintendo Switch
-- FTEQW (Windows, Mac, Linux, etc)
+- Nintendo 3DS (Old, New)
+- FTEQW (Windows, Mac, Linux, WebGL etc)
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,7 +10,7 @@ assignees: ''
 # When giving your report a title, please prepend a [LABEL], example [LABEL]s include:
 # [SERVER] (for game code), [CLIENT] (for HUD elements or other client side stuff),
 # [PSP/3DS/NX/VITA/FTE] (for engine based code specific to the platform).
-# If related to CO-OP, prepend "CO-OP/" to the label, (e.g. [CO-OP/SERVER].
+# If related to CO-OP, prepend "CO-OP/" to the label, (e.g. [CO-OP/SERVER]).
 **Describe the bug**
 A clear and concise description of what the bug is.
 
@@ -28,7 +28,6 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots or a video to help explain your problem.
 
 **Affected Platforms**
-
 # State which platform(s) you've seen the bug occur.
 # Please also make note of any platforms you DID NOT test on.
 

--- a/.github/ISSUE_TEMPLATE/suggestion.md
+++ b/.github/ISSUE_TEMPLATE/suggestion.md
@@ -1,0 +1,20 @@
+---
+name: Suggestion
+about: Create a suggestion for QoL changes
+title: '[SUGGESTION]'
+labels: 'enhancement'
+assignees: ''
+
+---
+
+**Describe your suggestion**
+A clear and concise description of what feature you'd like to be added.
+
+**Expected behavior**
+What you expect to happen or how it'll work in-game.
+
+**Screenshots/Footage**
+If applicable, add screenshots as a mock-up to help demonstrate what you want.
+
+**Additional context**
+Add any other context about the suggestion here.


### PR DESCRIPTION
Created a dedicated template for suggestions to make things clearer.
Also tidied up parts of the bug report template including removing the (now redundant) suggestions tidbit.