### PR TITLE
Removed deprecated warnings for GitHub Actions

### DIFF
--- a/.github/workflows/generate-nightly.yml
+++ b/.github/workflows/generate-nightly.yml
@@ -10,7 +10,7 @@ jobs:
     container:
       image: sharkwouter/pspdev
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Get apt ready
         run: |
           apt update
@@ -22,7 +22,7 @@ jobs:
           ./generate-nightly.sh ${{ secrets.GITHUB_TOKEN }}
       - name: Get Build Date
         id: date
-        run: echo "::set-output name=date::$(cat release_version.txt)"
+        run: echo "{name}={date::$(cat release_version.txt)}" >> $GITHUB_OUTPUT
       - name: Delete Old Release
         uses: dev-drprasad/delete-tag-and-release@v0.2.1
         with:


### PR DESCRIPTION
updated checkout to v4 using later version of nodejs. 

Also changed syntax for set-output to be updated due to future deprecation warning 

Before
![image](https://github.com/nzp-team/nzportable/assets/39999447/560afb6b-aa1b-438a-a998-32f1fe27bb6a)





After
![image](https://github.com/nzp-team/nzportable/assets/39999447/3ede9e22-cab1-4431-a47a-c87b70d9ac9e)
