### PR TITLE
Update configurations to support TI-NSPIRE

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -26,6 +26,7 @@ body:
           - OLD Nintendo 3DS
           - NEW Nintendo 3DS
           - PlayStation VITA
+          - TI-NSPIRE CX II
           - Microsoft Windows (x86)
           - Microsoft Windows (x86_64)
           - Linux (x86)

--- a/.github/workflows/generate-nightly.yml
+++ b/.github/workflows/generate-nightly.yml
@@ -42,6 +42,7 @@ jobs:
           body_path: changes.txt
           token: ${{ secrets.GITHUB_TOKEN }}
           files: |
+            ./out/nzportable-nspire.zip
             ./out/nzportable-3ds.zip
             ./out/nzportable-linux32.zip
             ./out/nzportable-linux64.zip
@@ -64,6 +65,7 @@ jobs:
           body_path: changes.txt
           token: ${{ secrets.GITHUB_TOKEN }}
           files: |
+            ./out/nzportable-nspire.zip
             ./out/nzportable-3ds.zip
             ./out/nzportable-linux32.zip
             ./out/nzportable-linux64.zip
@@ -86,6 +88,7 @@ jobs:
           body_path: changes.txt
           token: ${{ secrets.GITHUB_TOKEN }}
           files: |
+            ./out/nzportable-nspire.zip
             ./out/nzportable-3ds.zip
             ./out/nzportable-linux32.zip
             ./out/nzportable-linux64.zip
@@ -108,6 +111,7 @@ jobs:
           body_path: changes.txt
           token: ${{ secrets.GITHUB_TOKEN }}
           files: |
+            ./out/nzportable-nspire.zip
             ./out/nzportable-3ds.zip
             ./out/nzportable-linux32.zip
             ./out/nzportable-linux64.zip
@@ -130,6 +134,7 @@ jobs:
           body_path: changes.txt
           token: ${{ secrets.GITHUB_TOKEN }}
           files: |
+            ./out/nzportable-nspire.zip
             ./out/nzportable-3ds.zip
             ./out/nzportable-linux32.zip
             ./out/nzportable-linux64.zip
@@ -155,6 +160,7 @@ jobs:
       - name: Download data
         run: |
           wget https://github.com/nzp-team/nzportable/releases/download/nightly/build-version.txt
+          wget https://github.com/nzp-team/nzportable/releases/download/nightly/nzportable-nspire.zip
           wget https://github.com/nzp-team/nzportable/releases/download/nightly/nzportable-3ds.zip
           wget https://github.com/nzp-team/nzportable/releases/download/nightly/nzportable-linux32.zip
           wget https://github.com/nzp-team/nzportable/releases/download/nightly/nzportable-linux64.zip
@@ -254,5 +260,14 @@ jobs:
           itchUsername: nzp-team
           itchGameId: nazi-zombies-portable
           buildChannel: windows-x86_64
+          buildNumberFile: build-version.txt
+      - name: Upload to itch.io - TI-NSPIRE
+        uses: KikimoraGames/itch-publish@v0.0.3
+        with:
+          butlerApiKey: ${{secrets.BUTLER_API_KEY}}
+          gameData: nzportable-nzpire.zip
+          itchUsername: nzp-team
+          itchGameId: nazi-zombies-portable
+          buildChannel: nspire
           buildNumberFile: build-version.txt
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The game itself is feature-equivalent with Call of Duty: World at War on a gener
 * PlayStation VITA
 * [WebGL](https://nzp.gay)
 * Windows (x86, x86_64)
+* TI NSPIRE (CX II)
 
 # GitHub Organzation Breakdown
 * [assets](https://github.com/nzp-team/assets): Game GFX, Sound, etc. data.
@@ -58,6 +59,7 @@ Blubswillrule, Biodude, Cypress, Marty P.
 * fgsfdsfgs: Quakespasm-NX
 * MasterFeizz: ctrQuake
 * Rinnegatamante: Initial VITA port, VITA Auto-Updater
+* Ralf Willenbacher: nQuake
 * Azenn: GFX Assistance
 * BCDeshiG: Extensive Testing
 

--- a/generate-nightly.sh
+++ b/generate-nightly.sh
@@ -83,7 +83,7 @@ if [ "$QUAKC_UPDATE" -eq "1" ]; then
 fi
 
 if [ "$DQUAK_UPDATE" -eq "1" ]; then
-    printf "* Vril (PSP/3DS Engine)\n" >> changes.txt
+    printf "* Vril (PSP/3DS/NSPIRE Engine)\n" >> changes.txt
 fi
 
 if [ "$SPASM_UPDATE" -eq "1" ]; then
@@ -104,6 +104,7 @@ printf " into \`/switch/\` and launch with Homebrew Launcher. Requires extra mem
 printf " so make sure to open HBLauncher by holding 'R' over an installed title!\n" >> changes.txt
 printf "* PS VITA: Extract the .ZIP archive into ux0: and install \`nzp.vpk\`.\n" >> changes.txt
 printf "* Nintendo 3DS: Extract the .ZIP archive into \`/3ds/\`" >> changes.txt
+printf "* TI NSPIRE: Extract the .ZIP archive and sync contents to \`My Documents\`. \n" >> changes.txt
 printf "\n " >> changes.txt
 printf "\nYou can also play the WebGL version at https://nzp.gay/" >> changes.txt
 
@@ -117,10 +118,12 @@ wget -nc https://github.com/nzp-team/assets/releases/download/newest/pc-nzp-asse
 wget -nc https://github.com/nzp-team/assets/releases/download/newest/psp-nzp-assets.zip
 wget -nc https://github.com/nzp-team/assets/releases/download/newest/vita-nzp-assets.zip
 wget -nc https://github.com/nzp-team/assets/releases/download/newest/3ds-nzp-assets.zip
+wget -nc https://github.com/nzp-team/assets/releases/download/newest/nspire-nzp-assets.zip
 
 # Vril
 wget -nc https://github.com/nzp-team/vril-engine/releases/download/bleeding-edge/psp-nzp-eboot.zip
 wget -nc https://github.com/nzp-team/vril-engine/releases/download/bleeding-edge/ctr-nzp-3dsx.zip
+wget -nc https://github.com/nzp-team/vril-engine/releases/download/bleeding-edge/nspire-nzp-tns.zip
 
 # FTEQW
 wget -nc https://github.com/nzp-team/fteqw/releases/download/bleeding-edge/pc-nzp-linux32.zip
@@ -139,7 +142,7 @@ wget -nc https://github.com/nzp-team/quakespasm/releases/download/bleeding-edge/
 wget -nc https://github.com/nzp-team/quakespasm/releases/download/bleeding-edge/vita-nzp-vpk.zip
 
 # Directory setup
-mkdir -p {pc-assembly,psp-assembly,vita-assembly,nx-assembly,3ds-assembly,out}
+mkdir -p {pc-assembly,psp-assembly,vita-assembly,nx-assembly,3ds-assembly,nspire-assembly,out}
 echo $BUILD_STRING > release_version.txt
 
 #
@@ -260,4 +263,21 @@ cd assets/
 zip -q -r ../nzportable-3ds.zip ./*
 cd ../
 mv nzportable-3ds.zip ../out/
+cd ../
+
+#
+# Assemble TI-NSPIRE Build
+#
+cd nspire-assembly
+mkdir assets
+unzip -q ../nspire-nzp-assets.zip -d assets/
+unzip -q ../standard-nzp-qc.zip -d assets/nzp
+# Progs need renaming to .tns
+mv assets/nzp/progs.dat assets/nzp/progs.dat.tns
+unzip -q ../nspire-nzp-tns.zip -d assets/
+echo $BUILD_STRING > assets/nzp/version.txt.tns
+cd assets/
+zip -q -r ../nzportable-nspire.zip ./*
+cd ../
+mv nzportable-nspire.zip ../out/
 cd ../


### PR DESCRIPTION
This Pull Request revises documentation references and build scripts to support the TI-NSPIRE port proposed in https://github.com/nzp-team/vril-engine/pull/90

This port has only been tested on the TI-NSPIRE CX II, and is thus recommended due to double the processing power of the CX