### PR TITLE
Separate 3DS and TI NSPIRE

### DIFF
--- a/generate-nightly.sh
+++ b/generate-nightly.sh
@@ -103,7 +103,7 @@ printf "* Nintendo Switch: Extract the `nzportable` folder inside the .ZIP archi
 printf " into \`/switch/\` and launch with Homebrew Launcher. Requires extra memory," >> changes.txt
 printf " so make sure to open HBLauncher by holding 'R' over an installed title!\n" >> changes.txt
 printf "* PS VITA: Extract the .ZIP archive into ux0: and install \`nzp.vpk\`.\n" >> changes.txt
-printf "* Nintendo 3DS: Extract the .ZIP archive into \`/3ds/\`" >> changes.txt
+printf "* Nintendo 3DS: Extract the .ZIP archive into \`/3ds/\`.\n" >> changes.txt
 printf "* TI NSPIRE: Extract the .ZIP archive and sync contents to \`My Documents\`. \n" >> changes.txt
 printf "\n " >> changes.txt
 printf "\nYou can also play the WebGL version at https://nzp.gay/" >> changes.txt


### PR DESCRIPTION
In the current generate_nightly.sh, the Nintendo 3DS and TI NSPIRE are on the same line, as can be seen below:
![image](https://github.com/user-attachments/assets/4b2bf299-9c92-41e3-8a2e-1527edf7132a)
(Real world example is the current release in this repo: https://github.com/nzp-team/nzportable/releases/tag/nightly)

---

This PR is simple, it just separates the two onto separate lines for readability.
![image](https://github.com/user-attachments/assets/22d4fb7f-adce-4549-9e91-54e45f2bd1fe)
(Real world example is my fork of this repo: https://github.com/katniny/nzportable/releases/tag/nightly)