### PR TITLE
BUILD: Fix builds failing to GitHub API & add --force argument

### DIFF
--- a/.github/workflows/generate-nightly.yml
+++ b/.github/workflows/generate-nightly.yml
@@ -23,6 +23,7 @@ jobs:
             ./generate-nightly.sh --force
           else
             ./generate-nightly.sh
+          fi
       - name: Get Build Date
         id: date
         run: echo "::set-output name=date::$(cat release_version.txt)"

--- a/.github/workflows/generate-nightly.yml
+++ b/.github/workflows/generate-nightly.yml
@@ -19,7 +19,10 @@ jobs:
         continue-on-error: false
         working-directory: ./
         run: |
-          ./generate-nightly.sh ${{ secrets.GITHUB_TOKEN }}
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            ./generate-nightly.sh --force
+          else
+            ./generate-nightly.sh
       - name: Get Build Date
         id: date
         run: echo "::set-output name=date::$(cat release_version.txt)"

--- a/generate-nightly.sh
+++ b/generate-nightly.sh
@@ -2,7 +2,6 @@
 
 # Check for flags
 FORCE_RUN="0"
-GITHUB_TOKEN=""
 if [ "$1" = "--force" ] || [ "$1" = "-f" ]; then
     FORCE_RUN="1"
     shift

--- a/generate-nightly.sh
+++ b/generate-nightly.sh
@@ -22,11 +22,17 @@ YESTERDAY_TIME=$(expr $CURRENT_TIME - 86400)
 BUILD_STRING="2.0.0-indev+$(date +'%Y%m%d%H%M%S')"
 
 # Epoch times for every repo we care about
-ASSET_REPO_TIME=$(date "+%s" -d $(curl -s -H "Authorization: token $1" https://api.github.com/repos/nzp-team/assets/branches/main | jq '.commit.commit.author.date'| tr -d '"'))
-FTEQW_REPO_TIME=$(date "+%s" -d $(curl -s -H "Authorization: token $1" https://api.github.com/repos/nzp-team/fteqw/branches/main | jq '.commit.commit.author.date'| tr -d '"'))
-QUAKC_REPO_TIME=$(date "+%s" -d $(curl -s -H "Authorization: token $1" https://api.github.com/repos/nzp-team/quakec/branches/main | jq '.commit.commit.author.date'| tr -d '"'))
-DQUAK_REPO_TIME=$(date "+%s" -d $(curl -s -H "Authorization: token $1" https://api.github.com/repos/nzp-team/vril-engine/branches/main | jq '.commit.commit.author.date'| tr -d '"'))
-SPASM_REPO_TIME=$(date "+%s" -d $(curl -s -H "Authorization: token $1" https://api.github.com/repos/nzp-team/quakespasm/branches/main | jq '.commit.commit.author.date'| tr -d '"'))
+ASSET_REPO_TIME=$(date "+%s" -d $(curl -s https://api.github.com/repos/nzp-team/assets/branches/main | jq -r '.commit.commit.author.date'))
+FTEQW_REPO_TIME=$(date "+%s" -d $(curl -s https://api.github.com/repos/nzp-team/fteqw/branches/master | jq -r '.commit.commit.author.date'))
+QUAKC_REPO_TIME=$(date "+%s" -d $(curl -s https://api.github.com/repos/nzp-team/quakec/branches/main | jq -r '.commit.commit.author.date'))
+DQUAK_REPO_TIME=$(date "+%s" -d $(curl -s https://api.github.com/repos/nzp-team/vril-engine/branches/main | jq -r '.commit.commit.author.date'))
+SPASM_REPO_TIME=$(date "+%s" -d $(curl -s https://api.github.com/repos/nzp-team/quakespasm/branches/main | jq -r '.commit.commit.author.date'))
+
+echo "ASSET_REPO_TIME: $ASSET_REPO_TIME"
+echo "FTEQW_REPO_TIME: $FTEQW_REPO_TIME" 
+echo "QUAKC_REPO_TIME: $QUAKC_REPO_TIME"
+echo "DQUAK_REPO_TIME: $DQUAK_REPO_TIME"
+echo "SPASM_REPO_TIME: $SPASM_REPO_TIME"
 
 # Now check through them all and see if any have been updated recently
 if [ "$ASSET_REPO_TIME" -ge "$YESTERDAY_TIME" ]; then
@@ -142,7 +148,7 @@ wget -nc https://github.com/nzp-team/quakespasm/releases/download/bleeding-edge/
 wget -nc https://github.com/nzp-team/quakespasm/releases/download/bleeding-edge/vita-nzp-vpk.zip
 
 # Directory setup
-mkdir -p {pc-assembly,psp-assembly,vita-assembly,nx-assembly,3ds-assembly,nspire-assembly,out}
+mkdir -p {pc-assembly,psp-assembly,vita-assembly,nx-assembly,3ds-assembly,nspire-assembly,flatpak-assembly,out}
 echo $BUILD_STRING > release_version.txt
 
 #

--- a/generate-nightly.sh
+++ b/generate-nightly.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# Check for flags
+FORCE_RUN="0"
+GITHUB_TOKEN=""
+if [ "$1" = "--force" ] || [ "$1" = "-f" ]; then
+    FORCE_RUN="1"
+    shift
+fi
+
 # Whether to do a nightly
 PUSH_NIGHTLY="0"
 
@@ -28,12 +36,6 @@ QUAKC_REPO_TIME=$(date "+%s" -d $(curl -s https://api.github.com/repos/nzp-team/
 DQUAK_REPO_TIME=$(date "+%s" -d $(curl -s https://api.github.com/repos/nzp-team/vril-engine/branches/main | jq -r '.commit.commit.author.date'))
 SPASM_REPO_TIME=$(date "+%s" -d $(curl -s https://api.github.com/repos/nzp-team/quakespasm/branches/main | jq -r '.commit.commit.author.date'))
 
-echo "ASSET_REPO_TIME: $ASSET_REPO_TIME"
-echo "FTEQW_REPO_TIME: $FTEQW_REPO_TIME" 
-echo "QUAKC_REPO_TIME: $QUAKC_REPO_TIME"
-echo "DQUAK_REPO_TIME: $DQUAK_REPO_TIME"
-echo "SPASM_REPO_TIME: $SPASM_REPO_TIME"
-
 # Now check through them all and see if any have been updated recently
 if [ "$ASSET_REPO_TIME" -ge "$YESTERDAY_TIME" ]; then
     PUSH_NIGHTLY="1"
@@ -58,6 +60,11 @@ fi
 if [ "$SPASM_REPO_TIME" -ge "$YESTERDAY_TIME" ]; then
     PUSH_NIGHTLY="1"
     SPASM_UPDATE="1"
+fi
+
+# Check if the run was forced
+if [ "$FORCE_RUN" = "1" ]; then
+    PUSH_NIGHTLY="1"
 fi
 
 # Do we proceed?

--- a/generate-nightly.sh
+++ b/generate-nightly.sh
@@ -154,7 +154,7 @@ wget -nc https://github.com/nzp-team/quakespasm/releases/download/bleeding-edge/
 wget -nc https://github.com/nzp-team/quakespasm/releases/download/bleeding-edge/vita-nzp-vpk.zip
 
 # Directory setup
-mkdir -p {pc-assembly,psp-assembly,vita-assembly,nx-assembly,3ds-assembly,nspire-assembly,flatpak-assembly,out}
+mkdir -p {pc-assembly,psp-assembly,vita-assembly,nx-assembly,3ds-assembly,nspire-assembly,out}
 echo $BUILD_STRING > release_version.txt
 
 #


### PR DESCRIPTION
The `generate-nightly.sh` file was failing due to GitHub API calls returning `null`, causing dates to be `null` as well, and causing the build to fail.
While not always the case, this cases builds to be flaky in certain cases. This PR fixes this.

Also, the fixes by themselves would cause force pushes to still return `Nothing to do.`, so this adds a `--force` argument in the script, which the workflow will call accordingly (e.g., if forced, will add --force. If running at night, will not run force.)

--force will just let the script continue, regardless if there was actually a meaningful change in a repo, which makes the lives easier for anyone who may modifying a workflow, the script itself, or hopefully the Flatpak manifest in the near future!


See test run here: https://github.com/katniny/nzportable/actions/runs/16897557797/job/47870141636