### PR TITLE
Add Flatpak builds (Linux64 & Linuxarm64)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -34,6 +34,8 @@ body:
           - Linux (arm)
           - Linux (armhf)
           - Linux (arm64)
+          - Linux (Flatpak, x86_64)
+          - Linux (Flatpak, arm64)
           - WASM (Chromium-based browser)
           - WASM (Firefox-based browser)
           - WASM (WebKit-based browser)

--- a/.github/workflows/generate-nightly.yml
+++ b/.github/workflows/generate-nightly.yml
@@ -146,6 +146,93 @@ jobs:
             ./out/nzportable-win32.zip
             ./out/nzportable-win64.zip
             ./out/build-version.txt
+  
+  build-flatpak:
+    name: Build Flatpak
+    strategy:
+      fail-fast: false
+      matrix:
+        variant:
+          - arch: x86_64
+            runner: ubuntu-24.04
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.variant.runner }}
+    container:
+      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-48
+      options: --privileged
+    needs: Generate-Nightly
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Map CPU architecture to engine ZIP name
+        id: archmap
+        run: |
+          case "${{ matrix.variant.arch }}" in
+            x86_64)
+              echo "engine_arch=linux64" >> $GITHUB_OUTPUT
+              echo "engine_url=https://github.com/nzp-team/fteqw/releases/download/bleeding-edge/pc-nzp-linux64.zip" >> $GITHUB_OUTPUT
+              ;;
+            aarch64)
+              echo "engine_arch=linux_arm64" >> $GITHUB_OUTPUT
+              echo "engine_url=https://github.com/nzp-team/fteqw/releases/download/bleeding-edge/pc-nzp-linux_arm64.zip" >> $GITHUB_OUTPUT
+              ;;
+            *)
+              echo "Unsupported arch: ${{ matrix.variant.arch }}" && exit 1
+              ;;
+          esac
+      - name: Download Flatpak dependencies + add Flathub remote
+        run: |
+          flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+          sudo flatpak install -y flathub org.freedesktop.Platform//24.08 org.freedesktop.Sdk//24.08 || true
+      - name: Download release files to get sha256s
+        run: |
+          set -euo pipefail
+
+          # Set engine URL per arch
+          ENGINE_URL="${{ steps.archmap.outputs.engine_url }}"
+
+          # Get build string
+          wget -q https://github.com/nzp-team/nzportable/releases/download/nightly/build-version.txt
+          BUILD_STRING=$(cat build-version.txt)
+
+          # Download common/module archives (NZ:P assets/QC)
+          wget -q https://github.com/nzp-team/assets/releases/download/newest/pc-nzp-assets.zip -O pc-nzp-assets.zip
+          wget -q https://github.com/nzp-team/quakec/releases/download/bleeding-edge/fte-nzp-qc.zip -O fte-nzp-qc.zip
+
+          # Download engine ZIP
+          wget -q "$ENGINE_URL" -O fte-nzp-engine.zip
+
+          # Get sha256s
+          ASSETS_SHA=$(sha256sum pc-nzp-assets.zip | cut -d' ' -f1)
+          QUAKEC_SHA=$(sha256sum fte-nzp-qc.zip | cut -d' ' -f1)
+          FTEQW_SHA=$(sha256sum fte-nzp-engine.zip | cut -d' ' -f1)
+
+          # Replace placeholders in manifest
+          sed -i "s/ASSETS_SHA256_REPLACE/${ASSETS_SHA}/" gay.nzp.nzportable.json
+          sed -i "s/QC_SHA256_REPLACE/${QUAKEC_SHA}/" gay.nzp.nzportable.json
+          if [ "${{ matrix.variant.arch }}" = "x86_64" ]; then
+            sed -i "s/FTEQW64_SHA256_REPLACE/${FTEQW_SHA}/" gay.nzp.nzportable.json
+          else
+            sed -i "s/FTEQWARCH64_SHA256_REPLACE/${FTEQW_SHA}/" gay.nzp.nzportable.json
+          fi
+          sed -i "s/\"nightly\"/\"${BUILD_STRING}\"/" gay.nzp.nzportable.json
+
+          cat gay.nzp.nzportable.json
+      - name: Build Flatpak
+        uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+        with:
+          bundle: nzportable-${{ steps.archmap.outputs.engine_arch }}.flatpak
+          manifest-path: gay.nzp.nzportable.json
+          arch: ${{ matrix.variant.arch }}
+          cache-key: flatpak-builder-${{ github.sha }}-${{ matrix.variant.arch }}
+          verbose: true
+      - name: Upload Flatpak to release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: nightly
+          files: nzportable-${{ steps.archmap.outputs.engine_arch }}.flatpak
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   deploy-to-itch:
     name: Deploy to itch.io
@@ -171,6 +258,8 @@ jobs:
           wget https://github.com/nzp-team/nzportable/releases/download/nightly/nzportable-vita.zip
           wget https://github.com/nzp-team/nzportable/releases/download/nightly/nzportable-win32.zip
           wget https://github.com/nzp-team/nzportable/releases/download/nightly/nzportable-win64.zip
+          wget https://github.com/nzp-team/nzportable/releases/download/nightly/nzportable-linux64.flatpak
+          wget https://github.com/nzp-team/nzportable/releases/download/nightly/nzportable-linux_arm64.flatpak
       - name: Upload to itch.io - Nintendo 3DS
         uses: KikimoraGames/itch-publish@v0.0.3
         with:
@@ -269,5 +358,23 @@ jobs:
           itchUsername: nzp-team
           itchGameId: nazi-zombies-portable
           buildChannel: nspire
+          buildNumberFile: build-version.txt
+      - name: Upload to itch.io - Flatpak 64-bit
+        uses: KikimoraGames/itch-publish@v0.0.3
+        with:
+          butletApiKey: ${{ secrets.BUTLER_API_KEY }}
+          gameData: nzportable-linux64.flatpak
+          itchUsername: nzp-team
+          itchGameId: nazi-zombies-portable
+          buildChannel: linux64-flatpak
+          buildNumberFile: build-version.txt
+      - name: Upload to itch.io - Flatpak ARM64
+        uses: KikimoraGames/itch-publish@v0.0.3
+        with:
+          butletApiKey: ${{ secrets.BUTLER_API_KEY }}
+          gameData: nzportable-linux64.flatpak
+          itchUsername: nzp-team
+          itchGameId: nazi-zombies-portable
+          buildChannel: linux-arm64-flatpak
           buildNumberFile: build-version.txt
 

--- a/.github/workflows/generate-nightly.yml
+++ b/.github/workflows/generate-nightly.yml
@@ -170,59 +170,24 @@ jobs:
         run: |
           case "${{ matrix.variant.arch }}" in
             x86_64)
-              echo "engine_arch=linux64" >> $GITHUB_OUTPUT
-              echo "engine_url=https://github.com/nzp-team/fteqw/releases/download/bleeding-edge/pc-nzp-linux64.zip" >> $GITHUB_OUTPUT
+              echo "archive_arch=linux64" >> $GITHUB_OUTPUT
               ;;
             aarch64)
-              echo "engine_arch=linux_arm64" >> $GITHUB_OUTPUT
-              echo "engine_url=https://github.com/nzp-team/fteqw/releases/download/bleeding-edge/pc-nzp-linux_arm64.zip" >> $GITHUB_OUTPUT
-              ;;
-            *)
-              echo "Unsupported arch: ${{ matrix.variant.arch }}" && exit 1
+              echo "archive_arch=arm64" >> $GITHUB_OUTPUT
               ;;
           esac
       - name: Download Flatpak dependencies + add Flathub remote
         run: |
           flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
           sudo flatpak install -y flathub org.freedesktop.Platform//24.08 org.freedesktop.Sdk//24.08 || true
-      - name: Download release files to get sha256s
+      - name: Run generate-flatpak.sh
         run: |
-          set -euo pipefail
-
-          # Set engine URL per arch
-          ENGINE_URL="${{ steps.archmap.outputs.engine_url }}"
-
-          # Get build string
-          wget -q https://github.com/nzp-team/nzportable/releases/download/nightly/build-version.txt
-          BUILD_STRING=$(cat build-version.txt)
-
-          # Download common/module archives (NZ:P assets/QC)
-          wget -q https://github.com/nzp-team/assets/releases/download/newest/pc-nzp-assets.zip -O pc-nzp-assets.zip
-          wget -q https://github.com/nzp-team/quakec/releases/download/bleeding-edge/fte-nzp-qc.zip -O fte-nzp-qc.zip
-
-          # Download engine ZIP
-          wget -q "$ENGINE_URL" -O fte-nzp-engine.zip
-
-          # Get sha256s
-          ASSETS_SHA=$(sha256sum pc-nzp-assets.zip | cut -d' ' -f1)
-          QUAKEC_SHA=$(sha256sum fte-nzp-qc.zip | cut -d' ' -f1)
-          FTEQW_SHA=$(sha256sum fte-nzp-engine.zip | cut -d' ' -f1)
-
-          # Replace placeholders in manifest
-          sed -i "s/ASSETS_SHA256_REPLACE/${ASSETS_SHA}/" gay.nzp.nzportable.json
-          sed -i "s/QC_SHA256_REPLACE/${QUAKEC_SHA}/" gay.nzp.nzportable.json
-          if [ "${{ matrix.variant.arch }}" = "x86_64" ]; then
-            sed -i "s/FTEQW64_SHA256_REPLACE/${FTEQW_SHA}/" gay.nzp.nzportable.json
-          else
-            sed -i "s/FTEQWARCH64_SHA256_REPLACE/${FTEQW_SHA}/" gay.nzp.nzportable.json
-          fi
-          sed -i "s/\"nightly\"/\"${BUILD_STRING}\"/" gay.nzp.nzportable.json
-
-          cat gay.nzp.nzportable.json
+          chmod +x generate-flatpak.sh
+          ./generate-flatpak.sh "${{ matrix.variant.arch }}"
       - name: Build Flatpak
         uses: flatpak/flatpak-github-actions/flatpak-builder@v6
         with:
-          bundle: nzportable-${{ steps.archmap.outputs.engine_arch }}.flatpak
+          bundle: nzportable-${{ steps.archmap.outputs.archive_arch }}.flatpak
           manifest-path: gay.nzp.nzportable.json
           arch: ${{ matrix.variant.arch }}
           cache-key: flatpak-builder-${{ github.sha }}-${{ matrix.variant.arch }}
@@ -231,7 +196,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           tag_name: nightly
-          files: nzportable-${{ steps.archmap.outputs.engine_arch }}.flatpak
+          files: nzportable-${{ steps.archmap.outputs.archive_arch }}.flatpak
           token: ${{ secrets.GITHUB_TOKEN }}
 
   deploy-to-itch:

--- a/.github/workflows/generate-nightly.yml
+++ b/.github/workflows/generate-nightly.yml
@@ -372,7 +372,7 @@ jobs:
         uses: KikimoraGames/itch-publish@v0.0.3
         with:
           butletApiKey: ${{ secrets.BUTLER_API_KEY }}
-          gameData: nzportable-linux64.flatpak
+          gameData: nzportable-linux_arm64.flatpak
           itchUsername: nzp-team
           itchGameId: nazi-zombies-portable
           buildChannel: linux-arm64-flatpak

--- a/.github/workflows/generate-nightly.yml
+++ b/.github/workflows/generate-nightly.yml
@@ -182,7 +182,6 @@ jobs:
           sudo flatpak install -y flathub org.freedesktop.Platform//24.08 org.freedesktop.Sdk//24.08 || true
       - name: Run generate-flatpak.sh
         run: |
-          chmod +x generate-flatpak.sh
           ./generate-flatpak.sh "${{ matrix.variant.arch }}"
       - name: Build Flatpak
         uses: flatpak/flatpak-github-actions/flatpak-builder@v6

--- a/.github/workflows/generate-nightly.yml
+++ b/.github/workflows/generate-nightly.yml
@@ -258,8 +258,6 @@ jobs:
           wget https://github.com/nzp-team/nzportable/releases/download/nightly/nzportable-vita.zip
           wget https://github.com/nzp-team/nzportable/releases/download/nightly/nzportable-win32.zip
           wget https://github.com/nzp-team/nzportable/releases/download/nightly/nzportable-win64.zip
-          wget https://github.com/nzp-team/nzportable/releases/download/nightly/nzportable-linux64.flatpak
-          wget https://github.com/nzp-team/nzportable/releases/download/nightly/nzportable-linux_arm64.flatpak
       - name: Upload to itch.io - Nintendo 3DS
         uses: KikimoraGames/itch-publish@v0.0.3
         with:
@@ -359,22 +357,3 @@ jobs:
           itchGameId: nazi-zombies-portable
           buildChannel: nspire
           buildNumberFile: build-version.txt
-      - name: Upload to itch.io - Flatpak 64-bit
-        uses: KikimoraGames/itch-publish@v0.0.3
-        with:
-          butletApiKey: ${{ secrets.BUTLER_API_KEY }}
-          gameData: nzportable-linux64.flatpak
-          itchUsername: nzp-team
-          itchGameId: nazi-zombies-portable
-          buildChannel: linux64-flatpak
-          buildNumberFile: build-version.txt
-      - name: Upload to itch.io - Flatpak ARM64
-        uses: KikimoraGames/itch-publish@v0.0.3
-        with:
-          butletApiKey: ${{ secrets.BUTLER_API_KEY }}
-          gameData: nzportable-linux_arm64.flatpak
-          itchUsername: nzp-team
-          itchGameId: nazi-zombies-portable
-          buildChannel: linux-arm64-flatpak
-          buildNumberFile: build-version.txt
-

--- a/gay.nzp.nzportable.json
+++ b/gay.nzp.nzportable.json
@@ -18,26 +18,6 @@
     ],
     "modules": [
         {
-            "name": "nzportable-all",
-            "buildsystem": "simple",
-            "build-commands":  [
-                "mkdir -p /app/share/nzportable",
-                "cp -r * /app/share/nzportable/"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://github.com/nzp-team/assets/releases/download/newest/pc-nzp-assets.zip",
-                    "sha256": "ASSETS_SHA256_REPLACE"
-                },
-                {
-                    "type": "archive",
-                    "url": "https://github.com/nzp-team/quakec/releases/download/bleeding-edge/fte-nzp-qc.zip",
-                    "sha256": "QC_SHA256_REPLACE"
-                }
-            ]
-        },
-        {
             "name": "nzportable-linux64",
             "only-arches": [
                 "x86_64"
@@ -48,10 +28,12 @@
                 "mkdir -p /app/share/nzportable",
                 "# install the game binary",
                 "install -Dm755 nzportable64-sdl /app/share/nzportable/nzportable.bin",
+                "# install default.fmf",
+                "cp default.fmf /app/share/nzportable/",
                 "# install game data",
                 "mkdir -p /app/share/nzportable/nzp",
                 "for f in *; do if [ \"$f\" != \"nzportable64-sdl\" ] && [ \"$f\" != \"default.fmf\" ]; then cp -r \"$f\" /app/share/nzportable/nzp/; fi; done",
-                "echo \"$BUILD_STRING\" > /app/share/nzportable/nzp/version.txt",
+                "echo \"nightly\" > /app/share/nzportable/nzp/version.txt",
                 "printf '%s\\n' '#!/bin/bash' '' 'DATA_DIR=\"$HOME/.var/app/gay.nzp.nzportable/data\"' 'GAME_DIR=\"$DATA_DIR/nzportable\"' 'SOURCE_DIR=\"/app/share/nzportable\"' '' 'mkdir -p \"$DATA_DIR\"' '' 'if [ ! -d \"$GAME_DIR\" ] || [ ! -f \"$GAME_DIR/nzportable.bin\" ]; then' '    echo \"Setting up NZPortable data directory...\"' '    mkdir -p \"$GAME_DIR\"' '    cp -r \"$SOURCE_DIR\"/* \"$GAME_DIR/\"' '    chmod +x \"$GAME_DIR/nzportable.bin\"' '    echo \"Setup complete.\"' 'fi' '' 'if [ \"$SOURCE_DIR/nzp/version.txt\" -nt \"$GAME_DIR/nzp/version.txt\" ]; then' '    echo \"Updating game data...\"' '    # Preserve user settings' '    if [ -f \"$GAME_DIR/nzp/user_settings.cfg\" ]; then' '        cp \"$GAME_DIR/nzp/user_settings.cfg\" /tmp/nzp_user_settings_backup.cfg' '    fi' '    # Update game files' '    cp -r \"$SOURCE_DIR/nzp\"/* \"$GAME_DIR/nzp/\"' '    # Restore user settings' '    if [ -f \"/tmp/nzp_user_settings_backup.cfg\" ]; then' '        cp /tmp/nzp_user_settings_backup.cfg \"$GAME_DIR/nzp/user_settings.cfg\"' '        rm /tmp/nzp_user_settings_backup.cfg' '    fi' '    echo \"Update complete.\"' 'fi' '' 'cd \"$GAME_DIR\"' 'exec ./nzportable.bin \"$@\"' > nzportable-launcher",
                 "",
                 "install -Dm755 nzportable-launcher /app/bin/nzportable"
@@ -59,8 +41,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/nzp-team/fteqw/releases/download/bleeding-edge/pc-nzp-linux64.zip",
-                    "sha256": "FTEQW64_SHA256_REPLACE"
+                    "url": "https://github.com/nzp-team/nzportable/releases/download/nightly/nzportable-linux64.zip",
+                    "sha256": "ARCHIVE_SHA256_REPLACE"
                 }
             ]
         },
@@ -75,10 +57,12 @@
                 "mkdir -p /app/share/nzportable",
                 "# install the game binary",
                 "install -Dm755 nzportablearm64-sdl /app/share/nzportable/nzportable.bin",
+                "# install default.fmf",
+                "cp default.fmf /app/share/nzportable/",
                 "# install game data",
                 "mkdir -p /app/share/nzportable/nzp",
                 "for f in *; do if [ \"$f\" != \"nzportablearm64-sdl\" ] && [ \"$f\" != \"default.fmf\" ]; then cp -r \"$f\" /app/share/nzportable/nzp/; fi; done",
-                "echo \"$BUILD_STRING\" > /app/share/nzportable/nzp/version.txt",
+                "echo \"nightly\" > /app/share/nzportable/nzp/version.txt",
                 "printf '%s\\n' '#!/bin/bash' '' 'DATA_DIR=\"$HOME/.var/app/gay.nzp.nzportable/data\"' 'GAME_DIR=\"$DATA_DIR/nzportable\"' 'SOURCE_DIR=\"/app/share/nzportable\"' '' 'mkdir -p \"$DATA_DIR\"' '' 'if [ ! -d \"$GAME_DIR\" ] || [ ! -f \"$GAME_DIR/nzportable.bin\" ]; then' '    echo \"Setting up NZPortable data directory...\"' '    mkdir -p \"$GAME_DIR\"' '    cp -r \"$SOURCE_DIR\"/* \"$GAME_DIR/\"' '    chmod +x \"$GAME_DIR/nzportable.bin\"' '    echo \"Setup complete.\"' 'fi' '' 'if [ \"$SOURCE_DIR/nzp/version.txt\" -nt \"$GAME_DIR/nzp/version.txt\" ]; then' '    echo \"Updating game data...\"' '    # Preserve user settings' '    if [ -f \"$GAME_DIR/nzp/user_settings.cfg\" ]; then' '        cp \"$GAME_DIR/nzp/user_settings.cfg\" /tmp/nzp_user_settings_backup.cfg' '    fi' '    # Update game files' '    cp -r \"$SOURCE_DIR/nzp\"/* \"$GAME_DIR/nzp/\"' '    # Restore user settings' '    if [ -f \"/tmp/nzp_user_settings_backup.cfg\" ]; then' '        cp /tmp/nzp_user_settings_backup.cfg \"$GAME_DIR/nzp/user_settings.cfg\"' '        rm /tmp/nzp_user_settings_backup.cfg' '    fi' '    echo \"Update complete.\"' 'fi' '' 'cd \"$GAME_DIR\"' 'exec ./nzportable.bin \"$@\"' > nzportable-launcher",
                 "",
                 "install -Dm755 nzportable-launcher /app/bin/nzportable"
@@ -86,8 +70,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/nzp-team/fteqw/releases/download/bleeding-edge/pc-nzp-linux_arm64.zip",
-                    "sha256": "FTEQWARCH64_SHA256_REPLACE"
+                    "url": "https://github.com/nzp-team/nzportable/releases/download/nightly/nzportable-linuxarm64.zip",
+                    "sha256": "ARCHIVE_SHA256_REPLACE"
                 }
             ]
         }

--- a/gay.nzp.nzportable.json
+++ b/gay.nzp.nzportable.json
@@ -1,0 +1,95 @@
+{
+    "app-id": "gay.nzp.nzportable",
+    "runtime": "org.freedesktop.Platform",
+    "runtime-version": "24.08",
+    "sdk": "org.freedesktop.Sdk",
+    "command": "nzportable",
+    "finish-args": [
+        "--device=dri",
+        "--share=ipc",
+        "--socket=pulseaudio",
+        "--socket=x11",
+        "--socket=wayland",
+        "--env=SDL_VIDEODRIVER=x11",
+        "--env=SDL_AUDIODRIVER=pulseaudio",
+        "--filesystem=xdg-config",
+        "--share=network",
+        "--device=input"
+    ],
+    "modules": [
+        {
+            "name": "nzportable-all",
+            "buildsystem": "simple",
+            "build-commands":  [
+                "mkdir -p /app/share/nzportable",
+                "cp -r * /app/share/nzportable/"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/nzp-team/assets/releases/download/newest/pc-nzp-assets.zip",
+                    "sha256": "ASSETS_SHA256_REPLACE"
+                },
+                {
+                    "type": "archive",
+                    "url": "https://github.com/nzp-team/quakec/releases/download/bleeding-edge/fte-nzp-qc.zip",
+                    "sha256": "QC_SHA256_REPLACE"
+                }
+            ]
+        },
+        {
+            "name": "nzportable-linux64",
+            "only-arches": [
+                "x86_64"
+            ],
+            "buildsystem": "simple",
+            "build-commands": [
+                "mkdir -p /app/bin",
+                "mkdir -p /app/share/nzportable",
+                "# install the game binary",
+                "install -Dm755 nzportable64-sdl /app/share/nzportable/nzportable.bin",
+                "# install game data",
+                "mkdir -p /app/share/nzportable/nzp",
+                "for f in *; do if [ \"$f\" != \"nzportable64-sdl\" ] && [ \"$f\" != \"default.fmf\" ]; then cp -r \"$f\" /app/share/nzportable/nzp/; fi; done",
+                "echo \"$BUILD_STRING\" > /app/share/nzportable/nzp/version.txt",
+                "printf '%s\\n' '#!/bin/bash' '' 'DATA_DIR=\"$HOME/.var/app/gay.nzp.nzportable/data\"' 'GAME_DIR=\"$DATA_DIR/nzportable\"' 'SOURCE_DIR=\"/app/share/nzportable\"' '' 'mkdir -p \"$DATA_DIR\"' '' 'if [ ! -d \"$GAME_DIR\" ] || [ ! -f \"$GAME_DIR/nzportable.bin\" ]; then' '    echo \"Setting up NZPortable data directory...\"' '    mkdir -p \"$GAME_DIR\"' '    cp -r \"$SOURCE_DIR\"/* \"$GAME_DIR/\"' '    chmod +x \"$GAME_DIR/nzportable.bin\"' '    echo \"Setup complete.\"' 'fi' '' 'if [ \"$SOURCE_DIR/nzp/version.txt\" -nt \"$GAME_DIR/nzp/version.txt\" ]; then' '    echo \"Updating game data...\"' '    # Preserve user settings' '    if [ -f \"$GAME_DIR/nzp/user_settings.cfg\" ]; then' '        cp \"$GAME_DIR/nzp/user_settings.cfg\" /tmp/nzp_user_settings_backup.cfg' '    fi' '    # Update game files' '    cp -r \"$SOURCE_DIR/nzp\"/* \"$GAME_DIR/nzp/\"' '    # Restore user settings' '    if [ -f \"/tmp/nzp_user_settings_backup.cfg\" ]; then' '        cp /tmp/nzp_user_settings_backup.cfg \"$GAME_DIR/nzp/user_settings.cfg\"' '        rm /tmp/nzp_user_settings_backup.cfg' '    fi' '    echo \"Update complete.\"' 'fi' '' 'cd \"$GAME_DIR\"' 'exec ./nzportable.bin \"$@\"' > nzportable-launcher",
+                "",
+                "install -Dm755 nzportable-launcher /app/bin/nzportable"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/nzp-team/fteqw/releases/download/bleeding-edge/pc-nzp-linux64.zip",
+                    "sha256": "FTEQW64_SHA256_REPLACE"
+                }
+            ]
+        },
+        {
+            "name": "nzportable-arm64",
+            "only-arches": [
+                "aarch64"
+            ],
+            "buildsystem": "simple",
+            "build-commands": [
+                "mkdir -p /app/bin",
+                "mkdir -p /app/share/nzportable",
+                "# install the game binary",
+                "install -Dm755 nzportablearm64-sdl /app/share/nzportable/nzportable.bin",
+                "# install game data",
+                "mkdir -p /app/share/nzportable/nzp",
+                "for f in *; do if [ \"$f\" != \"nzportablearm64-sdl\" ] && [ \"$f\" != \"default.fmf\" ]; then cp -r \"$f\" /app/share/nzportable/nzp/; fi; done",
+                "echo \"$BUILD_STRING\" > /app/share/nzportable/nzp/version.txt",
+                "printf '%s\\n' '#!/bin/bash' '' 'DATA_DIR=\"$HOME/.var/app/gay.nzp.nzportable/data\"' 'GAME_DIR=\"$DATA_DIR/nzportable\"' 'SOURCE_DIR=\"/app/share/nzportable\"' '' 'mkdir -p \"$DATA_DIR\"' '' 'if [ ! -d \"$GAME_DIR\" ] || [ ! -f \"$GAME_DIR/nzportable.bin\" ]; then' '    echo \"Setting up NZPortable data directory...\"' '    mkdir -p \"$GAME_DIR\"' '    cp -r \"$SOURCE_DIR\"/* \"$GAME_DIR/\"' '    chmod +x \"$GAME_DIR/nzportable.bin\"' '    echo \"Setup complete.\"' 'fi' '' 'if [ \"$SOURCE_DIR/nzp/version.txt\" -nt \"$GAME_DIR/nzp/version.txt\" ]; then' '    echo \"Updating game data...\"' '    # Preserve user settings' '    if [ -f \"$GAME_DIR/nzp/user_settings.cfg\" ]; then' '        cp \"$GAME_DIR/nzp/user_settings.cfg\" /tmp/nzp_user_settings_backup.cfg' '    fi' '    # Update game files' '    cp -r \"$SOURCE_DIR/nzp\"/* \"$GAME_DIR/nzp/\"' '    # Restore user settings' '    if [ -f \"/tmp/nzp_user_settings_backup.cfg\" ]; then' '        cp /tmp/nzp_user_settings_backup.cfg \"$GAME_DIR/nzp/user_settings.cfg\"' '        rm /tmp/nzp_user_settings_backup.cfg' '    fi' '    echo \"Update complete.\"' 'fi' '' 'cd \"$GAME_DIR\"' 'exec ./nzportable.bin \"$@\"' > nzportable-launcher",
+                "",
+                "install -Dm755 nzportable-launcher /app/bin/nzportable"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/nzp-team/fteqw/releases/download/bleeding-edge/pc-nzp-linux_arm64.zip",
+                    "sha256": "FTEQWARCH64_SHA256_REPLACE"
+                }
+            ]
+        }
+    ]
+}

--- a/generate-flatpak.sh
+++ b/generate-flatpak.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+
+#
+# Downloads the latest nzportable release for the specified architecture (x86_64 and aarch64 respectively),
+# calculates the sha256 hash, then updates the Flatpak manifest file with the correct
+# hash and build version before the actual Flatpak build.
+#
+
 set -euo pipefail
 
 # Get architecture

--- a/generate-flatpak.sh
+++ b/generate-flatpak.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -euo pipefail
+
+# Get architecture
+ARCH="$1"
+
+# Set archive URL per arch
+case "$ARCH" in
+    x86_64)
+        ARCHIVE_URL="https://github.com/nzp-team/nzportable/releases/download/nightly/nzportable-linux64.zip"
+        ;;
+    aarch64)
+        ARCHIVE_URL="https://github.com/nzp-team/nzportable/releases/download/nightly/nzportable-linuxarm64.zip"
+        ;;
+    *)
+        echo "Unsupported arch: $ARCH" && exit 1
+        ;;
+esac
+
+# Get build version
+wget -q https://github.com/nzp-team/nzportable/releases/download/nightly/build-version.txt
+BUILD_VERSION=$(cat build-version.txt)
+
+# Download the archive
+wget -q "$ARCHIVE_URL" -O nzportable.zip
+
+# Get sha256
+ARCHIVE_SHA=$(sha256sum nzportable.zip | cut -d' ' -f1)
+
+# Replace placeholders in manifest
+sed -i "s/ARCHIVE_SHA256_REPLACE/${ARCHIVE_SHA}/" gay.nzp.nzportable.json
+sed -i "s/\"nightly\"/\"${BUILD_VERSION}\"/" gay.nzp.nzportable.json
+
+# Output the updated manifest
+cat gay.nzp.nzportable.json

--- a/generate-nightly.sh
+++ b/generate-nightly.sh
@@ -23,7 +23,7 @@ BUILD_STRING="2.0.0-indev+$(date +'%Y%m%d%H%M%S')"
 
 # Epoch times for every repo we care about
 ASSET_REPO_TIME=$(date "+%s" -d $(curl -s -H "Authorization: token $1" https://api.github.com/repos/nzp-team/assets/branches/main | jq '.commit.commit.author.date'| tr -d '"'))
-FTEQW_REPO_TIME=$(date "+%s" -d $(curl -s -H "Authorization: token $1" https://api.github.com/repos/nzp-team/fteqw/branches/main | jq '.commit.commit.author.date'| tr -d '"'))
+FTEQW_REPO_TIME=$(date "+%s" -d $(curl -s -H "Authorization: token $1" https://api.github.com/repos/nzp-team/fteqw/branches/master | jq '.commit.commit.author.date'| tr -d '"'))
 QUAKC_REPO_TIME=$(date "+%s" -d $(curl -s -H "Authorization: token $1" https://api.github.com/repos/nzp-team/quakec/branches/main | jq '.commit.commit.author.date'| tr -d '"'))
 DQUAK_REPO_TIME=$(date "+%s" -d $(curl -s -H "Authorization: token $1" https://api.github.com/repos/nzp-team/vril-engine/branches/main | jq '.commit.commit.author.date'| tr -d '"'))
 SPASM_REPO_TIME=$(date "+%s" -d $(curl -s -H "Authorization: token $1" https://api.github.com/repos/nzp-team/quakespasm/branches/main | jq '.commit.commit.author.date'| tr -d '"'))

--- a/generate-nightly.sh
+++ b/generate-nightly.sh
@@ -97,7 +97,7 @@ fi
 printf "\n " >> changes.txt
 printf "Installation Instructions:\n" >> changes.txt
 printf "* PC: Extract .ZIP archive into a folder of your choice. Linux users may need" >> changes.txt
-printf " to mark as executable with \`chmod\`\n" >> changes.txt
+printf " to mark as executable with \`chmod\`. Linux users may also choose to use the Flatpak.\n" >> changes.txt
 printf "* PSP: Extract the `nzportable` folder inside the .ZIP archive into \`PSP/GAME/\`.\n" >> changes.txt
 printf "* Nintendo Switch: Extract the `nzportable` folder inside the .ZIP archive" >> changes.txt
 printf " into \`/switch/\` and launch with Homebrew Launcher. Requires extra memory," >> changes.txt
@@ -142,7 +142,7 @@ wget -nc https://github.com/nzp-team/quakespasm/releases/download/bleeding-edge/
 wget -nc https://github.com/nzp-team/quakespasm/releases/download/bleeding-edge/vita-nzp-vpk.zip
 
 # Directory setup
-mkdir -p {pc-assembly,psp-assembly,vita-assembly,nx-assembly,3ds-assembly,nspire-assembly,out}
+mkdir -p {pc-assembly,psp-assembly,vita-assembly,nx-assembly,3ds-assembly,nspire-assembly,flatpak-assembly,out}
 echo $BUILD_STRING > release_version.txt
 
 #

--- a/generate-nightly.sh
+++ b/generate-nightly.sh
@@ -142,7 +142,7 @@ wget -nc https://github.com/nzp-team/quakespasm/releases/download/bleeding-edge/
 wget -nc https://github.com/nzp-team/quakespasm/releases/download/bleeding-edge/vita-nzp-vpk.zip
 
 # Directory setup
-mkdir -p {pc-assembly,psp-assembly,vita-assembly,nx-assembly,3ds-assembly,nspire-assembly,flatpak-assembly,out}
+mkdir -p {pc-assembly,psp-assembly,vita-assembly,nx-assembly,3ds-assembly,nspire-assembly,out}
 echo $BUILD_STRING > release_version.txt
 
 #


### PR DESCRIPTION
This PR adds Flatpak builds for the 64-bit and arm64 Linux builds of NZ:P.
Had to exclude 32-bit and armhf, since it's not supported by the freedesktop Platform or SDK (https://docs.flatpak.org/en/latest/available-runtimes.html).

This adds Flatpak building to the generate-nightly.yml file and adds the manifest file (gay.nzp.nzportable.json) for building.

This doesn't upload to Flathub, but I will open another PR if Flathub accepts our submission to implement Flathub integration as well. This just isn't necessary yet due to not being available on Flathub as of yet.